### PR TITLE
run_multi_gpu.sh: wait scheduler

### DIFF
--- a/tests/fserver/run_multi_gpu.sh
+++ b/tests/fserver/run_multi_gpu.sh
@@ -30,6 +30,8 @@ if [ $ROLE == "server" ]; then
   export DMLC_NODE_HOST=${SCHEDULER_IP}
   DMLC_ROLE=scheduler python3 $THIS_DIR/${BIN}.py &
 
+  sleep 1 # wait scheduler
+
   export DMLC_INTERFACE=auto
   for P in {0..7}; do
     DMLC_ROLE=server STEPMESH_GPU=${P} python3 $THIS_DIR/${BIN}.py $@ &


### PR DESCRIPTION
When I run the test script run_multi_gpu.sh, it randomly hangs. After debugging, I found that this is due to connection failures when the server tries to connect to the scheduler before the scheduler has started. Therefore, I've added a sleep delay to ensure the scheduler is fully started before the server attempts to connect.

After adding this sleep, my tests no longer experience any hanging issues.