### PR TITLE
benchmark: fix for pull key

### DIFF
--- a/fserver/csrc/public.hpp
+++ b/fserver/csrc/public.hpp
@@ -125,6 +125,10 @@ int push_pull(std::vector<torch::Tensor>& push_tensors,
               std::vector<uint64_t>& push_keys,
               std::vector<torch::Tensor>& pull_tensors,
               std::vector<uint64_t>& pull_keys) {
+
+  PS_CHECK_EQ(push_tensors.size(), push_keys.size());
+  PS_CHECK_EQ(pull_tensors.size(), pull_keys.size());
+
   auto push_batch = KeyTensorBatch(push_tensors.size());
   auto pull_batch = KeyTensorBatch(pull_tensors.size());
   for (size_t i = 0; i < push_tensors.size(); i++) {

--- a/tests/benchmark/bmk_comm_latency_multiserver.py
+++ b/tests/benchmark/bmk_comm_latency_multiserver.py
@@ -87,7 +87,7 @@ for mb in range(3):
         o_tensors += [torch.rand([num_token, dim], dtype=torch.bfloat16, device=f'cuda:{gpu}') for _ in range(bsz)]
     out_tensors_buffers.append(o_tensors)
 
-    out_tensors_keys.append([gen_pull_key(i, mb) for i in range(len(out_tensors_buffers))])
+    out_tensors_keys.append([gen_pull_key(i, mb) for i in range(len(o_tensors))])
 
 
 print_queue = Queue()


### PR DESCRIPTION
When I run the test using bmk_comm_latency_multiserver.py, I encounter the following error if the number of servers is not 1. The issue arises because an error occurs when generating the pull key, resulting in an incorrect key size. This commit fixes the problem.

/usr/include/c++/10/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = long unsigned int;
	_Alloc = std::allocator<long unsigned int>;
std::vector<_Tp, _Alloc>::reference = long unsigned int&; std::vector<_Tp, _Alloc>::size_type =
       long unsigned int]: Assertion '__builtin_expect(__n < this->size(), true)' failed.

On the other hand, this error message is very inconvenient for pinpointing the issue, so I have added PS_CHECK_EQ() to help quickly identify similar problems.