### PR TITLE
Using instance barrier inside fserver.init

### DIFF
--- a/fserver/csrc/public.hpp
+++ b/fserver/csrc/public.hpp
@@ -184,12 +184,12 @@ void init() {
   Backend::Get()->SetDevice(gpu_);
   if (role_ == Node::WORKER) {
     fworker_ = new AFTensorWorker(instance_id_);
-    barrier(true, true);
+    ps::Postoffice::GetWorker(instance_id_)->DoBarrier(0, ps::kServerGroup + ps::kWorkerGroup, true);
   } else if (role_ == Node::SERVER) {
     fserver_ = new AFTensorServer(instance_id_);
     fserver_->SetRequestHandle(RequestHandler);
     ps::RegisterExitCallback([]() { delete fserver_; });
-    barrier(true, true);
+    ps::Postoffice::GetServer(instance_id_)->DoBarrier(0, ps::kServerGroup + ps::kWorkerGroup, true);
   }
 }
 

--- a/include/ps/internal/postoffice.h
+++ b/include/ps/internal/postoffice.h
@@ -237,6 +237,13 @@ class Postoffice {
    */
   void Barrier(int customer_id, int node_group);
   /**
+   * \brief barrier for all postoffice instances or groups
+   * \param customer_id the id of the customer
+   * \param node_id the barrier group id
+   * \param instance_barrier whether it's for all postoffice instances or groups
+   */
+  void DoBarrier(int customer_id, int node_group, bool instance_barrier);
+  /**
    * \brief process a control message, called by van
    * \param the received message
    */
@@ -266,14 +273,6 @@ class Postoffice {
    */
   explicit Postoffice(int instance_idx);
   ~Postoffice() { delete van_; }
-
-  /**
-   * \brief barrier for all postoffice instances or groups
-   * \param customer_id the id of the customer
-   * \param node_id the barrier group id
-   * \param instance_barrier whether it's for all postoffice instances or groups
-   */
-  void DoBarrier(int customer_id, int node_group, bool instance_barrier);
 
   static Postoffice* po_scheduler_;
   static std::mutex init_mu_;

--- a/tests/benchmark/bmk_comm_latency_multiserver.py
+++ b/tests/benchmark/bmk_comm_latency_multiserver.py
@@ -171,7 +171,7 @@ def print_thread():
 if is_worker:
     th = threading.Thread(target=print_thread)
     th.start()
-    f.barrier(True, True)
+    f.barrier(False, True)
     q = Queue()
     time_list = []
     net_cost_list = [[] for _ in range(bsz + 1 + bsz)]


### PR DESCRIPTION
 In my test, there are two machines, so one worker and one server, with a
    group size of 8. There is always a deadlock occurring on worker instance
    0. This happens because during fserver init, both the worker and the
    server execute a barrier, but this barrier is not at the instance level.
    Therefore, in my scenario, as soon as any two instances (either server
    or worker) reach the barrier, those two instances can proceed further. I
    think this behavior is not reasonable. The cause of the deadlock lies in
    tests/benchmark/bmk_comm_latency_multiserver.py, where all workers also
    call f.barrier(True, True), which may lead to the following situation.

    * worker1-barrier-req
    * server1-barrier-req
    * worker1-barrier-done
    * server1-barrier-done

    * worker2-barrier-req
    * server2-barrier-req
    * worker2-barrier-done
    * server2-barrier-done

    * worker3-barrier-req
    * server3-barrier-req
    * worker3-barrier-done
    * server3-barrier-done

    * worker4-barrier-req
    * server4-barrier-req
    * worker4-barrier-done
    * server4-barrier-done

    * worker5-barrier-req
    * server5-barrier-req
    * worker5-barrier-done
    * server5-barrier-done

    * worker6-barrier-req
    * server6-barrier-req
    * worker6-barrier-done
    * server6-barrier-done

    * worker7-barrier-req
    * server7-barrier-req
    * worker7-barrier-done
    * server7-barrier-done

    * server0-barrier-req

    worker0 has not send the barrier req. so the server0 is waiting.

    Because the worker1-7 coimpleted the barrier inside fserver.init,
    then they goto the f.barrier(True, True) inside bmk_comm_latency_multiserver.py.

    * worker1-barrier-req
    * worker2-barrier-req
    * worker3-barrier-req
    * worker4-barrier-req
    * worker5-barrier-req
    * worker6-barrier-req
    * worker7-barrier-req

    So there are 8 barrier request and there are two groups, all the reqs meet the
    barrier condition.

    * server0-barrier-done
    * worker1-barrier-done
    * worker2-barrier-done
    * worker3-barrier-done
    * worker4-barrier-done
    * worker5-barrier-done
    * worker6-barrier-done
    * worker7-barrier-done

    Now the worker0 send the barrier req from fserver.init(), so the worker0
    is hang.

    * worker0-barrier-req (wait.......)


The issue here arises from the barrier call in the benchmark, which
    causes a conflict with the existing barrier. However, I believe the
    barrier in fserver.init should be at the instance level, rather than at
    the group level, as this would be safer and more reliable. Therefore,
    this patch changes the barrier in fserver.init to be instance-level.
