### PR TITLE
Update install_deps.sh with apt-get update first

### DIFF
--- a/tools/install_deps.sh
+++ b/tools/install_deps.sh
@@ -1,3 +1,4 @@
+sudo apt-get update
 sudo apt install -y build-essential libtool autoconf automake libnuma-dev unzip pkg-config librdmacm-dev rdma-core make cmake python3-pip
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ &> /dev/null && pwd )"


### PR DESCRIPTION
I face some issue like below in case not doing "sudo apt-get update" when I try to install StepMesh inside a docker container: E: Package 'libtool' has no installation candidate E: Package 'autoconf' has no installation candidate E: Package 'automake' has no installation candidate E: Unable to locate package pkg-config
E: Unable to locate package cmake